### PR TITLE
fix device map

### DIFF
--- a/internvl_chat/internvl/model/internlm2/modeling_internlm2.py
+++ b/internvl_chat/internvl/model/internlm2/modeling_internlm2.py
@@ -1082,13 +1082,16 @@ class InternLM2ForCausalLM(InternLM2PreTrainedModel):
             output = (logits,) + outputs[1:]
             return (loss,) + output if loss is not None else output
 
-        return CausalLMOutputWithPast(
+        device = input_ids.device if input_ids is not None else inputs_embeds.device
+        output = CausalLMOutputWithPast(
             loss=loss,
             logits=logits,
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )
+        output['logits'] = output['logits'].to(device)
+        return output
 
     def prepare_inputs_for_generation(
         self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs

--- a/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
+++ b/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
@@ -226,7 +226,7 @@ class InternVLChatModel(PreTrainedModel):
         vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], h, w, -1)
         vit_embeds = self.pixel_shuffle(vit_embeds, scale_factor=self.downsample_ratio)
         vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], -1, vit_embeds.shape[-1])
-        vit_embeds = self.mlp1(vit_embeds)
+        vit_embeds = self.mlp1(vit_embeds).to(pixel_values.device)
         return vit_embeds
 
     def chat(self, tokenizer, pixel_values, question, generation_config, history=None, return_history=False,


### PR DESCRIPTION
fix device map bugs
```
  File "/opt/conda/envs/hjh_swift/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/root/.cache/huggingface/modules/transformers_modules/checkpoint-200-merged/modeling_internvl_chat.py", line 359, in generate
    outputs = self.language_model.generate(
  File "/opt/conda/envs/hjh_swift/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda/envs/hjh_swift/lib/python3.9/site-packages/transformers/generation/utils.py", line 1575, in generate
    result = self._sample(
  File "/opt/conda/envs/hjh_swift/lib/python3.9/site-packages/transformers/generation/utils.py", line 2741, in _sample
    next_tokens = next_tokens * unfinished_sequences + pad_token_id * (1 - unfinished_sequences)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0!
```
and in `InternVLChatModel.foward`
```
vit_embeds = vit_embeds[image_flags == 1]
```
due to `InternVLChatModel.extract_feature` return tensor in other device