### PR TITLE
fix exception when pixel_values is None

### DIFF
--- a/clip_benchmark/clip_benchmark/models/intern_vit_6b/modeling_intern_vit.py
+++ b/clip_benchmark/clip_benchmark/models/intern_vit_6b/modeling_intern_vit.py
@@ -80,7 +80,7 @@ class InternVisionEmbeddings(nn.Module):
         self.position_embedding = nn.Parameter(torch.randn(1, self.num_positions, self.embed_dim))
 
     def forward(self, pixel_values: torch.FloatTensor) -> torch.Tensor:
-        batch_size = pixel_values.shape[0]
+        batch_size = 0 if pixel_values is None else pixel_values.shape[0]
         target_dtype = self.patch_embedding.weight.dtype
         patch_embeds = self.patch_embedding(pixel_values)  # shape = [*, width, grid, grid]
         patch_embeds = patch_embeds.flatten(2).transpose(1, 2)

--- a/clip_benchmark/clip_benchmark/models/internvl_huggingface/modeling_intern_vit.py
+++ b/clip_benchmark/clip_benchmark/models/internvl_huggingface/modeling_intern_vit.py
@@ -80,7 +80,7 @@ class InternVisionEmbeddings(nn.Module):
         self.position_embedding = nn.Parameter(torch.randn(1, self.num_positions, self.embed_dim))
 
     def forward(self, pixel_values: torch.FloatTensor) -> torch.Tensor:
-        batch_size = pixel_values.shape[0]
+        batch_size = 0 if pixel_values is None else pixel_values.shape[0]
         target_dtype = self.patch_embedding.weight.dtype
         patch_embeds = self.patch_embedding(pixel_values)  # shape = [*, width, grid, grid]
         patch_embeds = patch_embeds.flatten(2).transpose(1, 2)

--- a/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
+++ b/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
@@ -132,7 +132,7 @@ class InternVLChatModel(PreTrainedModel):
 
         vit_embeds = self.extract_feature(pixel_values)
         vit_embeds = vit_embeds[image_flags == 1]
-        vit_batch_size = pixel_values.shape[0]
+        vit_batch_size = 0 if pixel_values is None else pixel_values.shape[0]
 
         B, N, C = input_embeds.shape
         input_embeds = input_embeds.reshape(B * N, C)
@@ -251,7 +251,7 @@ class InternVLChatModel(PreTrainedModel):
         from .conversation import get_conv_template
 
         queries = []
-        image_bs = pixel_values.shape[0]
+        image_bs = 0 if pixel_values is None else pixel_values.shape[0]
         # print(f'dynamic ViT batch size: {image_bs}, image_counts: {image_counts}')
         for idx, image_count in enumerate(image_counts):
             image_token = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * self.num_image_token * image_count + IMG_END_TOKEN
@@ -289,7 +289,7 @@ class InternVLChatModel(PreTrainedModel):
         template = get_conv_template(self.template)
         eos_token_id = tokenizer.convert_tokens_to_ids(template.sep)
 
-        image_bs = pixel_values.shape[0]
+        image_bs = 0 if pixel_values is None else pixel_values.shape[0]
         print(f'dynamic ViT batch size: {image_bs}')
         if history is None:
             history = []
@@ -337,7 +337,7 @@ class InternVLChatModel(PreTrainedModel):
         if history is None:
             history = []
             image_tokens = ''
-            image_bs = pixel_values.shape[0]
+            image_bs = 0 if pixel_values is None else pixel_values.shape[0]
             print(f'dynamic ViT batch size: {image_bs}, image_counts: {image_counts}')
             for idx, image_count in enumerate(image_counts):
                 image_tokens += f'<image {idx+1}> (图{idx+1}):' + IMG_START_TOKEN + IMG_CONTEXT_TOKEN * self.num_image_token * image_count + IMG_END_TOKEN

--- a/internvl_chat_llava/llava/model/multimodal_encoder/eva_clip/modeling_evaclip.py
+++ b/internvl_chat_llava/llava/model/multimodal_encoder/eva_clip/modeling_evaclip.py
@@ -190,7 +190,7 @@ class EvaCLIPVisionEmbeddings(nn.Module):
         self.register_buffer("position_ids", torch.arange(self.num_positions).expand((1, -1)), persistent = False)
 
     def forward(self, pixel_values: torch.FloatTensor) -> torch.Tensor:
-        batch_size = pixel_values.shape[0]
+        batch_size = 0 if pixel_values is None else pixel_values.shape[0]
         patch_embeds = self.patch_embedding(pixel_values)  # shape = [*, width, grid, grid]
         patch_embeds = patch_embeds.flatten(2).transpose(1, 2)
 

--- a/internvl_g/internvl/model/internvl_stage2/modeling_intern_vit.py
+++ b/internvl_g/internvl/model/internvl_stage2/modeling_intern_vit.py
@@ -80,7 +80,7 @@ class InternVisionEmbeddings(nn.Module):
         self.position_embedding = nn.Parameter(torch.randn(1, self.num_positions, self.embed_dim))
 
     def forward(self, pixel_values: torch.FloatTensor) -> torch.Tensor:
-        batch_size = pixel_values.shape[0]
+        batch_size = 0 if pixel_values is None else pixel_values.shape[0]
         target_dtype = self.patch_embedding.weight.dtype
         patch_embeds = self.patch_embedding(pixel_values)  # shape = [*, width, grid, grid]
         patch_embeds = patch_embeds.flatten(2).transpose(1, 2)

--- a/internvl_g/internvl/model/internvl_stage2_retrieval/modeling_intern_vit.py
+++ b/internvl_g/internvl/model/internvl_stage2_retrieval/modeling_intern_vit.py
@@ -80,7 +80,7 @@ class InternVisionEmbeddings(nn.Module):
         self.position_embedding = nn.Parameter(torch.randn(1, self.num_positions, self.embed_dim))
 
     def forward(self, pixel_values: torch.FloatTensor) -> torch.Tensor:
-        batch_size = pixel_values.shape[0]
+        batch_size = 0 if pixel_values is None else pixel_values.shape[0]
         target_dtype = self.patch_embedding.weight.dtype
         patch_embeds = self.patch_embedding(pixel_values)  # shape = [*, width, grid, grid]
         patch_embeds = patch_embeds.flatten(2).transpose(1, 2)


### PR DESCRIPTION
When pass text content or image only in history, pixel_values  is None, then shape should set 0 to avoid exception.