### PR TITLE
Fix multi GPU inference on V100

### DIFF
--- a/internvl_chat/internvl/model/__init__.py
+++ b/internvl_chat/internvl/model/__init__.py
@@ -31,6 +31,7 @@ def split_model(num_layers, vit_alpha=0.5):
     device_map['language_model.model.norm'] = 0
     device_map['language_model.lm_head'] = 0
     device_map[f'language_model.model.layers.{num_layers - 1}'] = 0
+    device_map['language_model.model.rotary_emb'] = 0
 
     return device_map
 


### PR DESCRIPTION
Related to #774

Add `rotary_emb` layer to device map in `split_model` function to fix multi GPU inference error.

* Add `device_map['language_model.model.rotary_emb'] = 0` to the `split_model` function in `internvl_chat/internvl/model/__init__.py`.

