### PR TITLE
[Feature]V2PE

### DIFF
--- a/internvl_chat/internvl/model/internlm2/configuration_internlm2.py
+++ b/internvl_chat/internvl/model/internlm2/configuration_internlm2.py
@@ -95,6 +95,8 @@ class InternLM2Config(PretrainedConfig):
         rope_theta=10000,
         rope_scaling=None,
         attn_implementation='eager',
+        rope_pos_id_version='default',
+        rope_pos_id_stride=None,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -115,8 +117,10 @@ class InternLM2Config(PretrainedConfig):
         self.use_cache = use_cache
         self.rope_theta = rope_theta
         self.rope_scaling = rope_scaling
+        self.rope_pos_id_version = rope_pos_id_version
+        self.rope_pos_id_stride = rope_pos_id_stride
         self._rope_scaling_validation()
-
+        
         self.attn_implementation = attn_implementation
         if self.attn_implementation is None:
             self.attn_implementation = 'eager'

--- a/internvl_chat/internvl/model/internlm2/configuration_internlm2.py
+++ b/internvl_chat/internvl/model/internlm2/configuration_internlm2.py
@@ -120,7 +120,7 @@ class InternLM2Config(PretrainedConfig):
         self.rope_pos_id_version = rope_pos_id_version
         self.rope_pos_id_stride = rope_pos_id_stride
         self._rope_scaling_validation()
-        
+
         self.attn_implementation = attn_implementation
         if self.attn_implementation is None:
             self.attn_implementation = 'eager'

--- a/internvl_chat/internvl/model/internlm2/modeling_internlm2.py
+++ b/internvl_chat/internvl/model/internlm2/modeling_internlm2.py
@@ -324,12 +324,11 @@ class InternLM2Attention(nn.Module):
 
     def _init_rope(self):
         if self.config.rope_scaling is None:
-            if self.config.rope_pos_id_version == 'v2pe':
+            if self.config.rope_pos_id_version.startswith('v2pe_'):
                 self.rotary_emb = V2PE(
                     self.head_dim,
                     max_position_embeddings=self.max_position_embeddings,
                     base=self.config.rope_theta,
-                    rope_pos_id_stride=self.config.rope_pos_id_stride
                 )
             else:
                 self.rotary_emb = InternLM2RotaryEmbedding(
@@ -338,27 +337,32 @@ class InternLM2Attention(nn.Module):
                     base=self.config.rope_theta,
                 )
         else:
-            if self.config.rope_pos_id_version == 'v2pe':
-                raise ValueError("V2PE is not compatible with rope_scaling. When using V2PE, rope_scaling must be None.")
-            
-            scaling_type = self.config.rope_scaling["type"]
-            scaling_factor = self.config.rope_scaling["factor"]
-            if scaling_type == "linear":
-                self.rotary_emb = InternLM2LinearScalingRotaryEmbedding(
+            if self.config.rope_pos_id_version.startswith('v2pe_'):
+                warnings.warn(f"V2PE is not compatible with rope_scaling. When using V2PE, rope_scaling must be None. rope_scaling is {self.config.rope_scaling}")
+                self.rotary_emb = V2PE(
                     self.head_dim,
                     max_position_embeddings=self.max_position_embeddings,
-                    scaling_factor=scaling_factor,
-                    base=self.config.rope_theta,
-                )
-            elif scaling_type == "dynamic":
-                self.rotary_emb = InternLM2DynamicNTKScalingRotaryEmbedding(
-                    self.head_dim,
-                    max_position_embeddings=self.max_position_embeddings,
-                    scaling_factor=scaling_factor,
                     base=self.config.rope_theta,
                 )
             else:
-                raise ValueError(f"Unknown RoPE scaling type {scaling_type}")
+                scaling_type = self.config.rope_scaling["type"]
+                scaling_factor = self.config.rope_scaling["factor"]
+                if scaling_type == "linear":
+                    self.rotary_emb = InternLM2LinearScalingRotaryEmbedding(
+                        self.head_dim,
+                        max_position_embeddings=self.max_position_embeddings,
+                        scaling_factor=scaling_factor,
+                        base=self.config.rope_theta,
+                    )
+                elif scaling_type == "dynamic":
+                    self.rotary_emb = InternLM2DynamicNTKScalingRotaryEmbedding(
+                        self.head_dim,
+                        max_position_embeddings=self.max_position_embeddings,
+                        scaling_factor=scaling_factor,
+                        base=self.config.rope_theta,
+                    )
+                else:
+                    raise ValueError(f"Unknown RoPE scaling type {scaling_type}")
         return self.rotary_emb
 
     def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
@@ -403,8 +407,8 @@ class InternLM2Attention(nn.Module):
         kv_seq_len = key_states.shape[-2]
         if past_key_value is not None:
             kv_seq_len += past_key_value[0].shape[-2]
-        if self.config.rope_pos_id_version == 'v2pe':
-            cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+        if self.config.rope_pos_id_version.startswith('v2pe_'):
+            cos, sin = self.rotary_emb(value_states, global_posid=position_ids)
             query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, torch.arange(0,position_ids.shape[1]).unsqueeze(0))
         else:
             cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
@@ -509,8 +513,8 @@ class InternLM2FlashAttention2(InternLM2Attention):
         kv_seq_len = key_states.shape[-2]
         if past_key_value is not None:
             kv_seq_len += past_key_value[0].shape[-2]
-        if self.config.rope_pos_id_version == 'v2pe':
-            cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+        if self.config.rope_pos_id_version.startswith('v2pe_'):
+            cos, sin = self.rotary_emb(value_states, global_posid=position_ids)
             query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, torch.arange(0,position_ids.shape[1]).unsqueeze(0))
         else:
             cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)

--- a/internvl_chat/internvl/model/internlm2/modeling_internlm2.py
+++ b/internvl_chat/internvl/model/internlm2/modeling_internlm2.py
@@ -40,8 +40,9 @@ try:
 except:  # noqa # pylint: disable=bare-except
     BaseStreamer = None
 
-from .configuration_internlm2 import InternLM2Config
 from internvl.v2pe_utils import V2PE
+
+from .configuration_internlm2 import InternLM2Config
 
 logger = logging.get_logger(__name__)
 
@@ -338,23 +339,23 @@ class InternLM2Attention(nn.Module):
                 )
         else:
             if self.config.rope_pos_id_version.startswith('v2pe_'):
-                warnings.warn(f"V2PE is not compatible with rope_scaling. When using V2PE, rope_scaling must be None. rope_scaling is {self.config.rope_scaling}")
+                warnings.warn(f'V2PE is not compatible with rope_scaling. When using V2PE, rope_scaling must be None. rope_scaling is {self.config.rope_scaling}')
                 self.rotary_emb = V2PE(
                     self.head_dim,
                     max_position_embeddings=self.max_position_embeddings,
                     base=self.config.rope_theta,
                 )
             else:
-                scaling_type = self.config.rope_scaling["type"]
-                scaling_factor = self.config.rope_scaling["factor"]
-                if scaling_type == "linear":
+                scaling_type = self.config.rope_scaling['type']
+                scaling_factor = self.config.rope_scaling['factor']
+                if scaling_type == 'linear':
                     self.rotary_emb = InternLM2LinearScalingRotaryEmbedding(
                         self.head_dim,
                         max_position_embeddings=self.max_position_embeddings,
                         scaling_factor=scaling_factor,
                         base=self.config.rope_theta,
                     )
-                elif scaling_type == "dynamic":
+                elif scaling_type == 'dynamic':
                     self.rotary_emb = InternLM2DynamicNTKScalingRotaryEmbedding(
                         self.head_dim,
                         max_position_embeddings=self.max_position_embeddings,
@@ -362,7 +363,7 @@ class InternLM2Attention(nn.Module):
                         base=self.config.rope_theta,
                     )
                 else:
-                    raise ValueError(f"Unknown RoPE scaling type {scaling_type}")
+                    raise ValueError(f'Unknown RoPE scaling type {scaling_type}')
         return self.rotary_emb
 
     def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
@@ -1159,7 +1160,7 @@ class InternLM2ForCausalLM(InternLM2PreTrainedModel):
                 remove_prefix_length = input_ids.shape[1] - 1
 
             input_ids = input_ids[:, remove_prefix_length:]
-        
+
         position_ids = kwargs.get('position_ids', None)
         if attention_mask is not None and position_ids is None:
             # create position_ids on the fly for batch generation

--- a/internvl_chat/internvl/model/internvl_chat/configuration_internvl_chat.py
+++ b/internvl_chat/internvl/model/internvl_chat/configuration_internvl_chat.py
@@ -37,6 +37,8 @@ class InternVLChatConfig(PretrainedConfig):
             ps_version='v1',
             min_dynamic_patch=1,
             max_dynamic_patch=6,
+            rope_pos_id_version='default',
+            rope_pos_id_stride=None,
             **kwargs):
         super().__init__(**kwargs)
 
@@ -72,6 +74,8 @@ class InternVLChatConfig(PretrainedConfig):
         self.ps_version = ps_version  # pixel shuffle version
         self.min_dynamic_patch = min_dynamic_patch
         self.max_dynamic_patch = max_dynamic_patch
+        self.rope_pos_id_version = rope_pos_id_version
+        self.rope_pos_id_stride = rope_pos_id_stride
 
         self.hidden_size = self.llm_config.hidden_size
         # By default, we use tie_word_embeddings=False for models of all sizes.
@@ -82,6 +86,8 @@ class InternVLChatConfig(PretrainedConfig):
         logger.info(f'ps_version: {self.ps_version}')
         logger.info(f'min_dynamic_patch: {self.min_dynamic_patch}')
         logger.info(f'max_dynamic_patch: {self.max_dynamic_patch}')
+        logger.info(f'rope_pos_id_version: {self.rope_pos_id_version}')
+        logger.info(f'rope_pos_id_stride: {self.rope_pos_id_stride}')
 
     def to_dict(self):
         """
@@ -105,5 +111,7 @@ class InternVLChatConfig(PretrainedConfig):
         output['ps_version'] = self.ps_version
         output['min_dynamic_patch'] = self.min_dynamic_patch
         output['max_dynamic_patch'] = self.max_dynamic_patch
+        output['rope_pos_id_version'] = self.rope_pos_id_version
+        output['rope_pos_id_stride'] = self.rope_pos_id_stride
 
         return output

--- a/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
+++ b/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
@@ -13,6 +13,7 @@ import transformers
 from internvl.conversation import get_conv_template
 from internvl.model.internlm2.modeling_internlm2 import InternLM2ForCausalLM
 from internvl.model.phi3.modeling_phi3 import Phi3ForCausalLM
+from internvl.v2pe_utils import get_rope_pos_id
 from peft import LoraConfig, get_peft_model
 from torch import nn
 from torch.nn import CrossEntropyLoss
@@ -24,7 +25,6 @@ from transformers.utils import ModelOutput, logging
 
 from .configuration_internvl_chat import InternVLChatConfig
 from .modeling_intern_vit import InternVisionModel, has_flash_attn
-from internvl.v2pe_utils import get_rope_pos_id
 
 logger = logging.get_logger(__name__)
 

--- a/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
+++ b/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
@@ -383,25 +383,22 @@ class InternVLChatModel(PreTrainedModel):
         generation_config['eos_token_id'] = eos_token_id
         rope_pos_id_version = self.config.rope_pos_id_version
         if rope_pos_id_version.startswith('v2pe_'):
-            self.language_model.rope_pos_id_version = kwargs['rope_pos_id_version']
             pos_ids = []
             ret = {'input_ids': input_ids, 'attention_mask': attention_mask}
             for i in range(input_ids.shape[0]):
-
                 cur_dtype = torch.float32
                 rope_pos_id_stride = self.config.rope_pos_id_stride
-
-                cur_pos_id = get_rope_pos_id(ret, tokenizer=tokenizer, num_tiles=kwargs['num_tiles'][i],
+                cur_pos_id = get_rope_pos_id(ret, tokenizer=tokenizer,
                                            dtype=cur_dtype,
-                                           rope_pos_id_version=kwargs['rope_pos_id_version'],
+                                           rope_pos_id_version=rope_pos_id_version,
                                            position_id=torch.arange(0, input_ids.shape[1]),
                                            IMG_START_TOKEN=IMG_START_TOKEN,
-                                           IMG_END_TOKEN=IMG_END_TOKEN, rope_pos_id_stride=rope_pos_id_stride)
+                                           IMG_END_TOKEN=IMG_END_TOKEN, rope_pos_id_stride=rope_pos_id_stride, num_image_token=self.num_image_token)
 
                 cur_pos_id = torch.tensor(cur_pos_id).to(device)
                 pos_ids.append(cur_pos_id)
 
-            pos_ids = torch.stack(pos_ids)
+            pos_ids = torch.stack(pos_ids).to(device)
             generation_output = self.generate(
                 pixel_values=pixel_values,
                 input_ids=input_ids,

--- a/internvl_chat/internvl/patch/pad_data_collator.py
+++ b/internvl_chat/internvl/patch/pad_data_collator.py
@@ -72,7 +72,7 @@ def concat_pad_data_collator(features, max_item_length=None, pad_id=0):
         feat['attention_mask'] = feat['input_ids'].ne(pad_id)
 
         if 'position_ids' in feat:
-            temp_position_ids = torch.LongTensor([pad_id] * max_item_length)
+            temp_position_ids = [pad_id] * max_item_length
             temp_position_ids[:feat['position_ids'].shape[0]] = feat['position_ids']
             feat['position_ids'] = temp_position_ids
 

--- a/internvl_chat/internvl/train/dataset_packed.py
+++ b/internvl_chat/internvl/train/dataset_packed.py
@@ -246,12 +246,12 @@ class PackedDataset(IterableDataset):
                     buffer_data = buffer[k]
                 else:
                     buffer_data = buffer[k].tolist()
-                
+
                 if isinstance(new_sample[k], list):
                     new_data = new_sample[k]
                 else:
                     new_data = new_sample[k].tolist()
-                
+
                 buffer[k] = buffer_data + new_data
             else:
                 # Handle tensor type

--- a/internvl_chat/internvl/train/dataset_packed.py
+++ b/internvl_chat/internvl/train/dataset_packed.py
@@ -240,7 +240,22 @@ class PackedDataset(IterableDataset):
 
         assert buffer.keys() == new_sample.keys()
         for k in buffer:
-            buffer[k] = torch.cat([buffer[k], new_sample[k]])
+            if isinstance(buffer[k], list) or isinstance(new_sample[k], list):
+                # Handle list type
+                if isinstance(buffer[k], list):
+                    buffer_data = buffer[k]
+                else:
+                    buffer_data = buffer[k].tolist()
+                
+                if isinstance(new_sample[k], list):
+                    new_data = new_sample[k]
+                else:
+                    new_data = new_sample[k].tolist()
+                
+                buffer[k] = buffer_data + new_data
+            else:
+                # Handle tensor type
+                buffer[k] = torch.cat([buffer[k], new_sample[k]])
         return buffer
 
     @staticmethod

--- a/internvl_chat/internvl/train/internvl_chat_finetune.py
+++ b/internvl_chat/internvl/train/internvl_chat_finetune.py
@@ -276,7 +276,6 @@ class DataTrainingArguments:
     )
 
 
-
 class LazySupervisedDataset(Dataset):
     """Dataset for supervised fine-tuning."""
 
@@ -539,7 +538,7 @@ class LazySupervisedDataset(Dataset):
         if self.rope_pos_id_version in ['v2pe_fix', 'v2pe_rnd']:
             position_ids = get_rope_pos_id(ret, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer, num_image_token=self.num_image_token)
         else:
-            position_ids = position_ids[0]  
+            position_ids = position_ids[0]
         # Create the final return dictionary
         ret = dict(
             input_ids=ret['input_ids'][0],
@@ -1030,6 +1029,7 @@ def main():
         normalize_type=data_args.normalize_type, min_num_frame=data_args.min_num_frame,
         max_num_frame=data_args.max_num_frame,rope_pos_id_version=model_args.rope_pos_id_version,
         rope_pos_id_stride=model_args.rope_pos_id_stride)
+
     def _freeze_params(module):
         for param in module.parameters():
             param.requires_grad = False

--- a/internvl_chat/internvl/train/internvl_chat_finetune.py
+++ b/internvl_chat/internvl/train/internvl_chat_finetune.py
@@ -941,6 +941,10 @@ def main():
         config.ps_version = model_args.ps_version
         config.min_dynamic_patch = data_args.min_dynamic_patch
         config.max_dynamic_patch = data_args.max_dynamic_patch
+        config.rope_pos_id_version = model_args.rope_pos_id_version
+        config.rope_pos_id_stride = model_args.rope_pos_id_stride
+        config.llm_config.rope_pos_id_version = model_args.rope_pos_id_version
+        config.llm_config.rope_pos_id_stride = model_args.rope_pos_id_stride
         model = InternVLChatModel.from_pretrained(
             model_args.model_name_or_path, torch_dtype=torch.bfloat16, config=config)
     else:
@@ -970,6 +974,10 @@ def main():
             use_thumbnail=data_args.use_thumbnail, ps_version=model_args.ps_version,
             min_dynamic_patch=data_args.min_dynamic_patch, max_dynamic_patch=data_args.max_dynamic_patch)
         internvl_chat_config.force_image_size = data_args.force_image_size
+        internvl_chat_config.rope_pos_id_version = model_args.rope_pos_id_version
+        internvl_chat_config.rope_pos_id_stride = model_args.rope_pos_id_stride
+        internvl_chat_config.llm_config.rope_pos_id_version = model_args.rope_pos_id_version
+        internvl_chat_config.llm_config.rope_pos_id_stride = model_args.rope_pos_id_stride
         logger.info('Building InternVLChatModel...')
         model = InternVLChatModel(internvl_chat_config, vision_model, llm)
     model.img_context_token_id = img_context_token_id

--- a/internvl_chat/internvl/train/internvl_chat_finetune.py
+++ b/internvl_chat/internvl/train/internvl_chat_finetune.py
@@ -483,7 +483,7 @@ class LazySupervisedDataset(Dataset):
         assert (ret['input_ids'][0] == image_end_token_id).sum() == 1, f'image tokens are truncated, this dataset is {self.ds_name}'
 
         if self.rope_pos_id_version in ['v2pe_fix', 'v2pe_rnd']:
-            position_ids = get_rope_pos_id(ret, num_tiles, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer)
+            position_ids = get_rope_pos_id(ret, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer, num_image_token=self.num_image_token)
         else:
             position_ids = position_ids[0]
         # Create the final return dictionary
@@ -537,7 +537,7 @@ class LazySupervisedDataset(Dataset):
         assert (ret['input_ids'][0] == image_end_token_id).sum() == num_image, f'image tokens are truncated, this dataset is {self.ds_name}'
 
         if self.rope_pos_id_version in ['v2pe_fix', 'v2pe_rnd']:
-            position_ids = get_rope_pos_id(ret, num_tiles, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer)
+            position_ids = get_rope_pos_id(ret, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer, num_image_token=self.num_image_token)
         else:
             position_ids = position_ids[0]  
         # Create the final return dictionary
@@ -597,7 +597,7 @@ class LazySupervisedDataset(Dataset):
         position_ids.masked_fill_(ret['attention_mask'] == 0, 1)
 
         if self.rope_pos_id_version in ['v2pe_fix', 'v2pe_rnd']:
-            position_ids = get_rope_pos_id(ret, [1] * num_patches, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer)
+            position_ids = get_rope_pos_id(ret,  torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer, num_image_token=self.num_image_token)
         else:
             position_ids = position_ids[0]
         # Create the final return dictionary

--- a/internvl_chat/internvl/train/internvl_chat_pretrain.py
+++ b/internvl_chat/internvl/train/internvl_chat_pretrain.py
@@ -524,7 +524,7 @@ class LazySupervisedDataset(Dataset):
         assert (ret['input_ids'][0] == image_end_token_id).sum() == 1, f'image tokens are truncated, this dataset is {self.ds_name}'
 
         if self.rope_pos_id_version in ['v2pe_fix', 'v2pe_rnd']:
-            position_ids = get_rope_pos_id(ret, num_tiles, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer)
+            position_ids = get_rope_pos_id(ret, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer, num_image_token=self.num_image_token)
         else:
             position_ids = position_ids[0]
         # Create the final return dictionary
@@ -578,7 +578,7 @@ class LazySupervisedDataset(Dataset):
         assert (ret['input_ids'][0] == image_end_token_id).sum() == num_image, f'image tokens are truncated, this dataset is {self.ds_name}'
 
         if self.rope_pos_id_version in ['v2pe_fix', 'v2pe_rnd']:
-            position_ids = get_rope_pos_id(ret, num_tiles, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer)
+            position_ids = get_rope_pos_id(ret, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer, num_image_token=self.num_image_token)
         else:
             position_ids = position_ids[0]  
         # Create the final return dictionary
@@ -638,7 +638,7 @@ class LazySupervisedDataset(Dataset):
         position_ids.masked_fill_(ret['attention_mask'] == 0, 1)
 
         if self.rope_pos_id_version in ['v2pe_fix', 'v2pe_rnd']:
-            position_ids = get_rope_pos_id(ret, [1] * num_patches, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer)
+            position_ids = get_rope_pos_id(ret, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer, num_image_token=self.num_image_token)
         else:
             position_ids = position_ids[0]
         # Create the final return dictionary

--- a/internvl_chat/internvl/train/internvl_chat_pretrain.py
+++ b/internvl_chat/internvl/train/internvl_chat_pretrain.py
@@ -580,7 +580,7 @@ class LazySupervisedDataset(Dataset):
         if self.rope_pos_id_version in ['v2pe_fix', 'v2pe_rnd']:
             position_ids = get_rope_pos_id(ret, torch.float32, self.rope_pos_id_version, position_ids[0], tokenizer=self.tokenizer, num_image_token=self.num_image_token)
         else:
-            position_ids = position_ids[0]  
+            position_ids = position_ids[0]
         # Create the final return dictionary
         ret = dict(
             input_ids=ret['input_ids'][0],
@@ -683,7 +683,6 @@ class LazySupervisedDataset(Dataset):
         # Calculate position_ids for packed dataset
         position_ids = ret['attention_mask'].long().cumsum(-1) - 1
         position_ids.masked_fill_(ret['attention_mask'] == 0, 1)
-
 
         # Create the final return dictionary
         ret = dict(

--- a/internvl_chat/internvl/v2pe_utils.py
+++ b/internvl_chat/internvl/v2pe_utils.py
@@ -2,18 +2,17 @@ import torch
 import torch.nn as nn
 import random
 # get rope pos id while evaluating
-def get_rope_pos_id(ret, num_tiles, dtype, rope_pos_id_version='default', position_id=None,
-                    IMG_START_TOKEN='<img>',IMG_END_TOKEN='</img>',rope_pos_id_stride=None, tokenizer=None):
+def get_rope_pos_id(ret, dtype, rope_pos_id_version='default', position_id=None,
+                    IMG_START_TOKEN='<img>',IMG_END_TOKEN='</img>',rope_pos_id_stride=None, tokenizer=None, num_image_token=256):
     image_start_token_id = tokenizer.convert_tokens_to_ids(IMG_START_TOKEN)
     image_end_token_id = tokenizer.convert_tokens_to_ids(IMG_END_TOKEN)
-    num_image_token=256
     rope_pos_id_list = []
-
+    assert ret['input_ids'].shape[0] == 1, 'batch size should be 1, other batch sizes are not supported yet'
     input_ids_0 = ret['input_ids'][0]
     attention_mask_0 = ret['attention_mask'][0]
     image_start_token_id_idxs = torch.where(input_ids_0 == image_start_token_id)[0]
     image_end_token_id_idxs = torch.where(input_ids_0 == image_end_token_id)[0]
-
+    num_tiles = (image_end_token_id_idxs - image_start_token_id_idxs) // num_image_token
     last_record_pos_id = -1
     start_index = 0
 

--- a/internvl_chat/internvl/v2pe_utils.py
+++ b/internvl_chat/internvl/v2pe_utils.py
@@ -78,7 +78,7 @@ def get_rope_pos_id(ret, num_tiles, dtype, rope_pos_id_version='default', positi
 
 # Rotary Position Embedding for V2PE
 class V2PE(nn.Module):
-    def __init__(self, dim, max_position_embeddings=2048, base=10000, scaling_factor=1.0,scale_img=False):
+    def __init__(self, dim, max_position_embeddings=2048, base=10000, scaling_factor=1.0):
         super().__init__()
 
         self.dim = dim
@@ -86,7 +86,6 @@ class V2PE(nn.Module):
         self.base = base
         self.inv_freq = None
         self.scaling_factor=scaling_factor
-        self.scale_img=scale_img
         # inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim))
         # self.register_buffer('inv_freq', inv_freq, persistent=False)
 

--- a/internvl_chat/internvl/v2pe_utils.py
+++ b/internvl_chat/internvl/v2pe_utils.py
@@ -1,6 +1,9 @@
+import random
+
 import torch
 import torch.nn as nn
-import random
+
+
 # get rope pos id while evaluating
 def get_rope_pos_id(ret, dtype, rope_pos_id_version='default', position_id=None,
                     IMG_START_TOKEN='<img>',IMG_END_TOKEN='</img>',rope_pos_id_stride=None, tokenizer=None, num_image_token=256):
@@ -87,7 +90,7 @@ class V2PE(nn.Module):
         # inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim))
         # self.register_buffer('inv_freq', inv_freq, persistent=False)
 
-        self.max_seq_len_cached = -1 
+        self.max_seq_len_cached = -1
 
     def _set_cos_sin_cache(self, pos_id, device, dtype):
         if self.inv_freq is None:

--- a/internvl_chat/internvl/v2pe_utils.py
+++ b/internvl_chat/internvl/v2pe_utils.py
@@ -1,0 +1,116 @@
+import torch
+import torch.nn as nn
+import random
+# get rope pos id while evaluating
+def get_rope_pos_id(ret, num_tiles, dtype, rope_pos_id_version='default', position_id=None,
+                    IMG_START_TOKEN='<img>',IMG_END_TOKEN='</img>',rope_pos_id_stride=None, tokenizer=None):
+    image_start_token_id = tokenizer.convert_tokens_to_ids(IMG_START_TOKEN)
+    image_end_token_id = tokenizer.convert_tokens_to_ids(IMG_END_TOKEN)
+    num_image_token=256
+    rope_pos_id_list = []
+
+    input_ids_0 = ret['input_ids'][0]
+    attention_mask_0 = ret['attention_mask'][0]
+    image_start_token_id_idxs = torch.where(input_ids_0 == image_start_token_id)[0]
+    image_end_token_id_idxs = torch.where(input_ids_0 == image_end_token_id)[0]
+
+    last_record_pos_id = -1
+    start_index = 0
+
+    assert rope_pos_id_version in ['v2pe_fix', 'v2pe_rnd', 'default'], f'{rope_pos_id_version} not supported for eval'
+
+    for i in range(len(image_start_token_id_idxs)):
+
+        num_tile = num_tiles[i]
+
+        rope_pos_id_pre = attention_mask_0[start_index:image_start_token_id_idxs[i] + 1].long().cumsum(-1) - 1 + (last_record_pos_id + 1)
+        rope_pos_id_pre.masked_fill_(attention_mask_0[start_index:image_start_token_id_idxs[i] + 1] == 0, 1)
+        rope_pos_id_list.append(rope_pos_id_pre)
+
+        last_record_pos_id = rope_pos_id_pre[-1].long()
+
+        if rope_pos_id_version == 'v2pe_fix':
+            assert rope_pos_id_stride is not None, 'when rope_pos_id_version is fix, self.rope_pos_id_stride should not be None'
+            small_stride = rope_pos_id_stride / num_image_token
+            split_img_id_idxs = torch.linspace(last_record_pos_id,last_record_pos_id+small_stride*(num_image_token * num_tile ),(num_image_token * num_tile + 1))[1:].to(dtype=dtype)
+            rope_pos_id_list.append(split_img_id_idxs)
+            last_record_pos_id = torch.ceil(split_img_id_idxs[-1]).long()
+        elif rope_pos_id_version == 'v2pe_rnd':
+            random_from=[1,2,4,8,16,32,64,128,256]
+            rope_pos_id_stride=random.choice(random_from)
+            small_stride = rope_pos_id_stride / num_image_token
+            split_img_id_idxs = torch.linspace(last_record_pos_id,last_record_pos_id+small_stride*(num_image_token * num_tile ),(num_image_token * num_tile + 1))[1:].to(dtype=dtype)
+            rope_pos_id_list.append(split_img_id_idxs)
+            last_record_pos_id = torch.ceil(split_img_id_idxs[-1]).long()
+        elif rope_pos_id_version == 'default':
+            split_img_id_idxs = torch.linspace(last_record_pos_id,
+                                               last_record_pos_id + (num_tile - 1) * num_image_token,
+                                               (num_tile - 1) * num_image_token + 1)[1:].to(dtype=dtype)
+            rope_pos_id_list.append(split_img_id_idxs)
+            thumbnail_id_idxs = torch.linspace(last_record_pos_id + (num_tile - 1) * num_image_token,
+                                               last_record_pos_id + num_tile * num_image_token,
+                                               num_image_token + 1)[1:].to(dtype=dtype)
+            rope_pos_id_list.append(thumbnail_id_idxs)
+            last_record_pos_id = (last_record_pos_id + num_tile * num_image_token).long()
+        else:
+            raise NotImplementedError(f'not implement for {rope_pos_id_version}')
+
+        start_index = image_start_token_id_idxs[i] + num_tile * num_image_token + 1
+        assert input_ids_0[start_index] == image_end_token_id
+        assert start_index == image_end_token_id_idxs[i]
+
+    assert image_end_token_id_idxs[-1] == start_index
+    rope_pos_id_pre = attention_mask_0[start_index:].long().cumsum(-1) - 1 + (last_record_pos_id + 1)
+    rope_pos_id_pre.masked_fill_(attention_mask_0[start_index:] == 0, 1)
+    rope_pos_id_list.append(rope_pos_id_pre)
+
+    rope_pos_id_list=[_.to('cpu') for _ in rope_pos_id_list]
+    rope_pos_id = torch.cat(rope_pos_id_list).to(dtype=dtype)
+    if rope_pos_id_version == 'default':
+        rope_pos_id = rope_pos_id.long()
+        assert torch.equal(rope_pos_id, position_id.to(rope_pos_id.device)), (rope_pos_id, position_id.to(rope_pos_id.device))
+        assert torch.allclose(rope_pos_id, position_id.to(rope_pos_id.device), atol=1e-32)
+
+    assert rope_pos_id.shape == input_ids_0.shape
+
+    return list(rope_pos_id.numpy())
+
+
+# Rotary Position Embedding for V2PE
+class V2PE(nn.Module):
+    def __init__(self, dim, max_position_embeddings=2048, base=10000, scaling_factor=1.0,scale_img=False):
+        super().__init__()
+
+        self.dim = dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+        self.inv_freq = None
+        self.scaling_factor=scaling_factor
+        self.scale_img=scale_img
+        # inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim))
+        # self.register_buffer('inv_freq', inv_freq, persistent=False)
+
+        self.max_seq_len_cached = -1 
+
+    def _set_cos_sin_cache(self, pos_id, device, dtype):
+        if self.inv_freq is None:
+            inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2, device=device, dtype=torch.float32) / self.dim))
+            del self.inv_freq
+            self.register_buffer('inv_freq', inv_freq, persistent=False)
+
+        pos_id=pos_id.squeeze(0)
+        freqs = torch.outer(pos_id, self.inv_freq.to(device=pos_id.device))
+
+        # Different from paper, but it uses a different permutation in order to obtain the same calculation
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer('cos_cached', emb.cos().to(dtype), persistent=False)
+        self.register_buffer('sin_cached', emb.sin().to(dtype), persistent=False)
+
+    def forward(self, x, global_posid=None):
+        # x: [bs, num_attention_heads, seq_len, head_size]
+        self._set_cos_sin_cache(pos_id=global_posid, device=x.device, dtype=x.dtype,selected=selected)
+
+        return (
+            self.cos_cached[:].to(dtype=x.dtype),
+            self.sin_cached[:].to(dtype=x.dtype),
+        )

--- a/internvl_chat/internvl/v2pe_utils.py
+++ b/internvl_chat/internvl/v2pe_utils.py
@@ -78,14 +78,13 @@ def get_rope_pos_id(ret, num_tiles, dtype, rope_pos_id_version='default', positi
 
 # Rotary Position Embedding for V2PE
 class V2PE(nn.Module):
-    def __init__(self, dim, max_position_embeddings=2048, base=10000, scaling_factor=1.0):
+    def __init__(self, dim, max_position_embeddings=2048, base=10000):
         super().__init__()
 
         self.dim = dim
         self.max_position_embeddings = max_position_embeddings
         self.base = base
         self.inv_freq = None
-        self.scaling_factor=scaling_factor
         # inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim))
         # self.register_buffer('inv_freq', inv_freq, persistent=False)
 
@@ -107,7 +106,7 @@ class V2PE(nn.Module):
 
     def forward(self, x, global_posid=None):
         # x: [bs, num_attention_heads, seq_len, head_size]
-        self._set_cos_sin_cache(pos_id=global_posid, device=x.device, dtype=x.dtype,selected=selected)
+        self._set_cos_sin_cache(pos_id=global_posid, device=x.device, dtype=x.dtype)
 
         return (
             self.cos_cached[:].to(dtype=x.dtype),


### PR DESCRIPTION
## Motivation

Support V2PE in pre-training, fine-tuning, and inference for InternVL.

## Modification

### V2PE utils

Added the file `internvl_chat/internvl/v2pe_utils.py`.  
It includes the `get_rope_pos_id` function, which calculates position ids required for V2PE,  
and a `V2PE` module that can replace the conventional RoPE mechanism.

### Pre-training and Fine-tuning

Modified the following files to support V2PE in training and fine-tuning:

- `internvl_chat/internvl/train/internvl_chat_pretrain.py`
- `internvl_chat/internvl/train/internvl_chat_finetune.py`

Specifically:
- Extended `ModelArguments` and `LazySupervisedDataset` to support V2PE.
- Updated `concat_pad_data_collator` in `internvl_chat/internvl/patch/pad_data_collator.py`  
  to support passing position ids as lists (to preserve float precision when using V2PE).

### Model

#### InternVLChat

- Modified `internvl_chat/internvl/model/internvl_chat/configuration_internvl_chat.py`  
  to support passing V2PE-related arguments via config.
- Updated `InternVLChatModel.forward()` and `InternVLChatModel.chat()`  
  in `internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py`  
  to support V2PE usage during both training and inference.

#### InternLM2

- Modified `internvl_chat/internvl/model/internlm2/configuration_internlm2.py`  
  to support V2PE-related config arguments.
- Updated `InternLM2Attention._init_rope()`, `InternLM2Attention.forward()`,  
  and `InternLM2FlashAttention2.forward()` in  
  `internvl_chat/internvl/model/internlm2/modeling_internlm2.py`  
  to support replacing RoPE with the V2PE module.
