### PR TITLE
update modeling_internvl_chat.py to call self.post_init() at the end of __init__  (line 110)

### DIFF
--- a/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
+++ b/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py
@@ -106,7 +106,8 @@ class InternVLChatModel(PreTrainedModel):
 
         if config.use_llm_lora:
             self.wrap_llm_lora(r=config.use_llm_lora, lora_alpha=2 * config.use_llm_lora)
-
+        # Initialize weights and apply final processing. See: https://github.com/huggingface/transformers/pull/37708
+        self.post_init()
     def wrap_backbone_lora(self, r=128, lora_alpha=256, lora_dropout=0.05):
         lora_config = LoraConfig(
             r=r,


### PR DESCRIPTION
Currently, InternVLChatModel does not call self.post_init() during initialization, leaving model._tp_plan as None. When using AutoModelForCausalLM.from_pretrained, this can lead to a TypeError: 'NoneType' object is not iterable, because from_pretrained may invoke caching_allocator_warmup(), which expects model._tp_plan to be properly defined.

Please see: https://github.com/huggingface/transformers/pull/37708.