### PR TITLE
Fix multi-round conversation template for GPT-OSS

### DIFF
--- a/internvl_chat_gpt_oss/internvl/model/internvl_chat/conversation.py
+++ b/internvl_chat_gpt_oss/internvl/model/internvl_chat/conversation.py
@@ -255,7 +255,13 @@ class Conversation:
                 if message:
                     if type(message) is tuple:
                         message, _, _ = message
-                    ret += role + message + seps[i % 2]
+                    # Check if this is the last message and it's from assistant
+                    is_last_message = (i == len(self.messages) - 1)
+                    is_assistant = role == self.roles[1]  # roles[1] is assistant role
+                    
+                    # Use sep2 only for the last assistant message, otherwise use sep
+                    separator = self.sep2 if (is_last_message and is_assistant) else self.sep
+                    ret += role + message + separator
                 else:
                     ret += role
             return ret

--- a/internvl_chat_gpt_oss/internvl/train/dataset.py
+++ b/internvl_chat_gpt_oss/internvl/train/dataset.py
@@ -535,7 +535,8 @@ def preprocess_internvl3_5_gpt_oss(
             batches.append(f'<|start|>user<|message|>{conversation["value"]}<|end|>')
             roles.append('human')
         elif conversation['from'] == 'gpt':
-            batches.append(f'<|start|>assistant<|channel|>final<|message|>{conversation["value"]}<|return|>')
+            eos = '<|return|>' if i == len(conversations) - 1 else '<|end|>' # '<|return|>' if last message else '<|end|>'
+            batches.append(f'<|start|>assistant<|channel|>final<|message|>{conversation["value"]}{eos}')
             roles.append('gpt')
         elif conversation['from'] == 'function':
             batches.append(f'<|start|>tool<|message|>{conversation["value"]}<|end|>')


### PR DESCRIPTION
### Issue:

The current `MPT_TWO` separator style in `conversation.py` and batch formulation in `dataset.py` alternates between `<|end|>` and `<|return|>` for each message, which is incorrect for multi-turn conversations. For the [template](https://huggingface.co/openai/gpt-oss-20b/blob/main/chat_template.jinja) of GPT-OSS, `<|return|>` should only be used at the end of the final assistant response, while all other messages should use `<|end|>`.

### Fix:
Modified the **alternates** logic to:
- Use `<|return|>` only for the last message when it's from the assistant
- Use `<|end|>` for all other messages (including intermediate assistant responses)

### Example
**Before:**
```
<|start|>user<|message|>Hello<|end|>
<|start|>assistant<|channel|>final<|message|>Hi there<|return|>
<|start|>user<|message|>Thanks<|end|>
<|start|>assistant<|channel|>final<|message|>You're welcome<|return|>
```

**After:**
```
<|start|>user<|message|>Hello<|end|>
<|start|>assistant<|channel|>final<|message|>Hi there<|end|>
<|start|>user<|message|>Thanks<|end|>
<|start|>assistant<|channel|>final<|message|>You're welcome<|return|>
```

This fix ensures proper conversation flow for future multi-turn dialogue datasets.