### PR TITLE
Update accuracy_reward.py 中的编辑距离相似度计算规则。

### DIFF
--- a/internvl_chat/tools/reasoning_data_pipeline/utils/accuracy_reward.py
+++ b/internvl_chat/tools/reasoning_data_pipeline/utils/accuracy_reward.py
@@ -512,7 +512,8 @@ def check_answer(answer_pred, answer_gt, mode):
         det_answer = ' '.join(answer_pred.strip().lower().split())
         dist = levenshtein_distance(gt_answer, det_answer)
         length = max(len(answer_gt.upper()), len(answer_pred.upper()))
-        accuracy = max(accuracy, float(dist) / float(length))
+        similarity = 1 -  float(dist) / float(length)
+        accuracy = max(accuracy, similarity)
 
     if 'mc_score' in mode:
         accuracy = max(accuracy, multi_choice_score(answer_pred, answer_gt))


### PR DESCRIPTION
原来的编辑距离相似度准确性是错误的，比较的是编辑距离即不相似度。